### PR TITLE
Add proxy and client scripts

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,0 +1,31 @@
+import sys
+import socket
+
+SOCKET_PATH = '/tmp/proxy_socket'
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: client.py '<command>'")
+        sys.exit(1)
+
+    command = sys.argv[1]
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.connect(SOCKET_PATH)
+    try:
+        sock.sendall(command.encode())
+        sock.shutdown(socket.SHUT_WR)
+        data = b''
+        while True:
+            chunk = sock.recv(1024)
+            if not chunk:
+                break
+            data += chunk
+        print(data.decode().rstrip())
+    finally:
+        sock.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/proxy.py
+++ b/proxy.py
@@ -1,0 +1,65 @@
+import sys
+import os
+import socket
+import signal
+import shlex
+import pexpect
+
+SOCKET_PATH = '/tmp/proxy_socket'
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: proxy.py '<command>'")
+        sys.exit(1)
+
+    command = sys.argv[1]
+    args = shlex.split(command)
+
+    if os.path.exists(SOCKET_PATH):
+        os.remove(SOCKET_PATH)
+
+    child = pexpect.spawn(args[0], args[1:], encoding='utf-8', echo=False)
+
+    # wait for initial prompt
+    try:
+        child.expect('> ')
+    except pexpect.EOF:
+        print('Process exited unexpectedly')
+        sys.exit(1)
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.bind(SOCKET_PATH)
+    sock.listen(1)
+
+    def cleanup(signum=None, frame=None):
+        try:
+            os.remove(SOCKET_PATH)
+        except OSError:
+            pass
+        child.close(force=True)
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, cleanup)
+    signal.signal(signal.SIGTERM, cleanup)
+
+    while True:
+        conn, _ = sock.accept()
+        with conn:
+            data = b''
+            while True:
+                chunk = conn.recv(1024)
+                if not chunk:
+                    break
+                data += chunk
+            command = data.decode().strip()
+            if not command:
+                continue
+            child.sendline(command)
+            child.expect('> ')
+            response = child.before
+            conn.sendall(response.encode())
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `proxy.py` to run an interactive program and expose a Unix socket
- add `client.py` to send a command to the proxy and print the reply

## Testing
- `python3 -m py_compile proxy.py client.py`

------
https://chatgpt.com/codex/tasks/task_e_6841bbd9d63c8326bbc9b629fb965d92